### PR TITLE
Added Tooltips for the Colorblind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 EnderStorage
 ============
+EnderStorage is a mod that offers a means to store your items in The END, causing them to be everywhere and nowhere at the same time. All EnderStorage makes use of the magic of colors to link storage with its little piece of The END. Any EnderStorage with the same color code share inventory (even across dimensions). Currently there are three types of storage, EnderChest, EnderPouch, and EnderTank.
 
-This is a port of Chickenbones EnderStorage Mod with added support for the colorblind.
+EnderChests are a stationary type of EnderStorage. You can use dye on the wool pads on top of the chest to alter its color code. As an alternative, you can craft an EnderChest with three dyes to change the color code as well. EnderChests work as any other chest for the purposes of blocks that manipulate chests contents. This makes EnderChests an ideal way to transport items over vast distances in an instant.
+
+EnderPouches are a mobile type of EnderStorage. You can use an EnderPouch on any EnderChest to change the pouch color code to match that of the chest. EnderPouches access the same inventory as their EnderChest counterparts, allowing easy access to your base resources right from your inventory.
+
+EnderTanks are a stationary type of EnderStorage. You can use dye on the wool pads on top of the tank to alter its color code. EnderTanks work as a tank to store liquids. Right clicking on the dial on the front will change it between input (blue) and output (orange) mode.
+
+Current recommended and latest builds can be found at http://chickenbones.net/Pages/links.html

--- a/README.md
+++ b/README.md
@@ -1,11 +1,4 @@
 EnderStorage
 ============
-EnderStorage is a mod that offers a means to store your items in The END, causing them to be everywhere and nowhere at the same time. All EnderStorage makes use of the magic of colors to link storage with its little piece of The END. Any EnderStorage with the same color code share inventory (even across dimensions). Currently there are three types of storage, EnderChest, EnderPouch, and EnderTank.
 
-EnderChests are a stationary type of EnderStorage. You can use dye on the wool pads on top of the chest to alter its color code. As an alternative, you can craft an EnderChest with three dyes to change the color code as well. EnderChests work as any other chest for the purposes of blocks that manipulate chests contents. This makes EnderChests an ideal way to transport items over vast distances in an instant.
-
-EnderPouches are a mobile type of EnderStorage. You can use an EnderPouch on any EnderChest to change the pouch color code to match that of the chest. EnderPouches access the same inventory as their EnderChest counterparts, allowing easy access to your base resources right from your inventory.
-
-EnderTanks are a stationary type of EnderStorage. You can use dye on the wool pads on top of the tank to alter its color code. EnderTanks work as a tank to store liquids. Right clicking on the dial on the front will change it between input (blue) and output (orange) mode.
-
-Current recommended and latest builds can be found at http://chickenbones.net/Pages/links.html
+This is a port of Chickenbones EnderStorage Mod with added support for the colorblind.

--- a/resources/assets/enderstorage/lang/de_DE.lang
+++ b/resources/assets/enderstorage/lang/de_DE.lang
@@ -3,7 +3,24 @@ tile.enderchest|1.name=Endertank
 item.enderpouch.name=Enderbeutel
 enderstorage.serverop=Operator
 
-enderstorage.serverop=Operatorenderstorage.command.usage=enderstorage <Freq>|(<Farbe> <Farbe> <Farbe>) [Eigentümer]
+enderstorage.colours.Black=Schwarz
+enderstorage.colours.Red=Rot
+enderstorage.colours.Green=Grün
+enderstorage.colours.Brown=Braun
+enderstorage.colours.Purple=Violett
+enderstorage.colours.Cyan=Türkis
+enderstorage.colours.LightGray=Hellgrau
+enderstorage.colours.Gray=Grau
+enderstorage.colours.Lime=Hellgrün
+enderstorage.colours.Yellow=Gelb
+enderstorage.colours.LightBlue=Hellblau
+enderstorage.colours.Magenta=Magenta
+enderstorage.colours.Orange=Orange
+enderstorage.colours.White=Weiß
+enderstorage.colours.Pink=Pink
+enderstorage.colours.Blue=Blau
+
+enderstorage.command.usage=enderstorage <Freq>|(<Farbe> <Farbe> <Farbe>) [Eigentümer]
 enderstorage.command.no_arguments=Ungültige Anzahl an Parametern
 enderstorage.command.no_freq=Ungültige Frequenz
 enderstorage.command.no_colour=Ungültige Farbe: %s

--- a/resources/assets/enderstorage/lang/en_US.lang
+++ b/resources/assets/enderstorage/lang/en_US.lang
@@ -3,6 +3,23 @@ tile.enderchest|1.name=Ender Tank
 item.enderpouch.name=Ender Pouch
 enderstorage.serverop=Operator
 
+enderstorage.colours.Black=Black
+enderstorage.colours.Red=Red
+enderstorage.colours.Green=Green
+enderstorage.colours.Brown=Brown
+enderstorage.colours.Purple=Purple
+enderstorage.colours.Cyan=Cyan
+enderstorage.colours.LightGray=Light Gray
+enderstorage.colours.Gray=Gray
+enderstorage.colours.Lime=Lime
+enderstorage.colours.Yellow=Yellow
+enderstorage.colours.LightBlue=Light Blue
+enderstorage.colours.Magenta=Magenta
+enderstorage.colours.Orange=Orange
+enderstorage.colours.White=White
+enderstorage.colours.Pink=Pink
+enderstorage.colours.Blue=Blue
+
 enderstorage.command.usage=enderstorage <freq>|(<colour> <colour> <colour>) [owner]
 enderstorage.command.no_arguments=Invalid number of arguments
 enderstorage.command.no_freq=Invalid freq

--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -8,11 +8,16 @@ Credits: Ecu - original idea, design,
         chest and pouch texture
     Rosethorns - tank model
     Soaryn - tank texture
+	
+Supporters: Blkdragon112
 
-Supporters: Blkdragon112",
+Note: This version by mallrat208. Please report issues @
+      https://github.com/mallrat208/EnderStorage/issues
+
+",
   "version": "${version}",
   "mcversion": "${mc_version}",
-  "url": "http://www.minecraftforum.net/topic/909223",
+  "url": "",
   "authorList": [ "ChickenBones" ],
   "dependencies": [ "CodeChickenCore" ]
 }

--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -8,16 +8,11 @@ Credits: Ecu - original idea, design,
         chest and pouch texture
     Rosethorns - tank model
     Soaryn - tank texture
-	
-Supporters: Blkdragon112
 
-Note: This version by mallrat208. Please report issues @
-      https://github.com/mallrat208/EnderStorage/issues
-
-",
+Supporters: Blkdragon112",
   "version": "${version}",
   "mcversion": "${mc_version}",
-  "url": "",
+  "url": "http://www.minecraftforum.net/topic/909223",
   "authorList": [ "ChickenBones" ],
   "dependencies": [ "CodeChickenCore" ]
 }

--- a/src/codechicken/enderstorage/EnderStorage.java
+++ b/src/codechicken/enderstorage/EnderStorage.java
@@ -39,6 +39,7 @@ public class EnderStorage
     public static Item personalItem;
     public static boolean disableVanillaEnderChest;
     public static boolean removeVanillaRecipe;
+    public static boolean enableColorblindMode;
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
@@ -52,7 +53,8 @@ public class EnderStorage
         loadPersonalItem();
         disableVanillaEnderChest = config.getTag("disable-vanilla").setComment("Set to true to make the vanilla enderchest unplaceable.").getBooleanValue(true);
         removeVanillaRecipe = config.getTag("disable-vanilla_recipe").setComment("Set to true to make the vanilla enderchest uncraftable.").getBooleanValue(false);
-
+        enableColorblindMode = config.getTag("enable-colorblind-mode").setComment("Set to true to enable Colorblind Mode for Tooltips.").getBooleanValue(false);
+        
         EnderStorageManager.loadConfig(config);
         EnderStorageManager.registerPlugin(new EnderItemStoragePlugin());
         EnderStorageManager.registerPlugin(new EnderLiquidStoragePlugin());

--- a/src/codechicken/enderstorage/api/EnderStorageManager.java
+++ b/src/codechicken/enderstorage/api/EnderStorageManager.java
@@ -178,16 +178,15 @@ public class EnderStorageManager
         return ((colours[0] & 0xF) << 8) + ((colours[1] & 0xF) << 4) + (colours[2] & 0xF);
     }
 
-    public static String getUnlocalizedColorDesc(ItemStack stack)
-    {
+    public static String getLocalizedColorDesc(ItemStack stack)
+    { 	
     	int rgbFreq[] = EnderStorageManager.getColoursFromFreq(stack.getItemDamage());
     	String rgbColour[] = new String[3];
     	for (int i=0;i<3;i++)
-    	{
-    		rgbColour[i] = EnderStorageRecipe.oreDictionaryNames[Math.abs(rgbFreq[i]-15)].substring(3);
-    	}
-    	String desc = StatCollector.translateToLocal("enderstorage.colours."+rgbColour[0].toString()) + " - " + StatCollector.translateToLocal("enderstorage.colours." + rgbColour[1].toString()) + " - " + StatCollector.translateToLocal("enderstorage.colours." + rgbColour[2].toString()); 
-    	return desc;
+    		{
+    			rgbColour[i] = StatCollector.translateToLocal("enderstorage.colours." + EnderStorageRecipe.oreDictionaryNames[Math.abs(rgbFreq[i]-15)].substring(3));
+    		}
+    	return rgbColour[0] + "/" + rgbColour[1] + "/" + rgbColour[2]; 
     }
     
     public static int getColourFromFreq(int freq, int colour) {

--- a/src/codechicken/enderstorage/api/EnderStorageManager.java
+++ b/src/codechicken/enderstorage/api/EnderStorageManager.java
@@ -15,9 +15,11 @@ import java.util.Map.Entry;
 
 import codechicken.enderstorage.common.EnderStorageRecipe;
 import codechicken.lib.config.ConfigFile;
+
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
+
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;

--- a/src/codechicken/enderstorage/api/EnderStorageManager.java
+++ b/src/codechicken/enderstorage/api/EnderStorageManager.java
@@ -13,13 +13,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import codechicken.enderstorage.common.EnderStorageRecipe;
 import codechicken.lib.config.ConfigFile;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.event.world.WorldEvent.Load;
 import net.minecraftforge.event.world.WorldEvent.Save;
@@ -175,6 +178,18 @@ public class EnderStorageManager
         return ((colours[0] & 0xF) << 8) + ((colours[1] & 0xF) << 4) + (colours[2] & 0xF);
     }
 
+    public static String getUnlocalizedColorDesc(ItemStack stack)
+    {
+    	int rgbFreq[] = EnderStorageManager.getColoursFromFreq(stack.getItemDamage());
+    	String rgbColour[] = new String[3];
+    	for (int i=0;i<3;i++)
+    	{
+    		rgbColour[i] = EnderStorageRecipe.oreDictionaryNames[Math.abs(rgbFreq[i]-15)].substring(3);
+    	}
+    	String desc = StatCollector.translateToLocal("enderstorage.colours."+rgbColour[0].toString()) + " - " + StatCollector.translateToLocal("enderstorage.colours." + rgbColour[1].toString()) + " - " + StatCollector.translateToLocal("enderstorage.colours." + rgbColour[2].toString()); 
+    	return desc;
+    }
+    
     public static int getColourFromFreq(int freq, int colour) {
         switch (colour) {
             case 0:

--- a/src/codechicken/enderstorage/common/ItemEnderStorage.java
+++ b/src/codechicken/enderstorage/common/ItemEnderStorage.java
@@ -2,6 +2,7 @@ package codechicken.enderstorage.common;
 
 import java.util.List;
 
+import codechicken.enderstorage.api.EnderStorageManager;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
@@ -46,7 +47,9 @@ public class ItemEnderStorage extends ItemBlock
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean extended)
     {
-        if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
+    	list.subList(1, list.size()).clear();
+    	if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
             list.add(stack.getTagCompound().getString("owner"));
+    	list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));
     }
 }

--- a/src/codechicken/enderstorage/common/ItemEnderStorage.java
+++ b/src/codechicken/enderstorage/common/ItemEnderStorage.java
@@ -2,6 +2,7 @@ package codechicken.enderstorage.common;
 
 import java.util.List;
 
+import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
@@ -50,6 +51,6 @@ public class ItemEnderStorage extends ItemBlock
     	list.subList(1, list.size()).clear();
     	if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
             list.add(stack.getTagCompound().getString("owner"));
-    	list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));
+    	if(EnderStorage.enableColorblindMode) list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));
     }
 }

--- a/src/codechicken/enderstorage/common/ItemEnderStorage.java
+++ b/src/codechicken/enderstorage/common/ItemEnderStorage.java
@@ -51,6 +51,6 @@ public class ItemEnderStorage extends ItemBlock
     	list.subList(1, list.size()).clear();
     	if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
             list.add(stack.getTagCompound().getString("owner"));
-    	if(EnderStorage.enableColorblindMode) list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));
+    	if(EnderStorage.enableColorblindMode) list.add(EnderStorageManager.getLocalizedColorDesc(stack));
     }
 }

--- a/src/codechicken/enderstorage/common/ItemEnderStorage.java
+++ b/src/codechicken/enderstorage/common/ItemEnderStorage.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;

--- a/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
+++ b/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
@@ -42,7 +42,7 @@ public class ItemEnderPouch extends Item
     	if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
             list.add(stack.getTagCompound().getString("owner"));
     	
-    	if(EnderStorage.enableColorblindMode) list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));	     	       
+    	if(EnderStorage.enableColorblindMode) list.add(EnderStorageManager.getLocalizedColorDesc(stack));	     	       
         
     }
   

--- a/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
+++ b/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import codechicken.lib.render.SpriteSheetManager;
 import codechicken.lib.render.SpriteSheetManager.SpriteSheet;
+import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
 import codechicken.enderstorage.common.EnderStorageRecipe;
 import cpw.mods.fml.relauncher.Side;
@@ -41,7 +42,7 @@ public class ItemEnderPouch extends Item
     	if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
             list.add(stack.getTagCompound().getString("owner"));
     	
-    	list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));	     	       
+    	if(EnderStorage.enableColorblindMode) list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));	     	       
         
     }
   

--- a/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
+++ b/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
@@ -6,9 +6,10 @@ import codechicken.lib.render.SpriteSheetManager;
 import codechicken.lib.render.SpriteSheetManager.SpriteSheet;
 import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
-import codechicken.enderstorage.common.EnderStorageRecipe;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -18,7 +19,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.StringUtils;
 import net.minecraft.world.World;
 
 public class ItemEnderPouch extends Item

--- a/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
+++ b/src/codechicken/enderstorage/storage/item/ItemEnderPouch.java
@@ -5,9 +5,9 @@ import java.util.List;
 import codechicken.lib.render.SpriteSheetManager;
 import codechicken.lib.render.SpriteSheetManager.SpriteSheet;
 import codechicken.enderstorage.api.EnderStorageManager;
+import codechicken.enderstorage.common.EnderStorageRecipe;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -17,6 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StringUtils;
 import net.minecraft.world.World;
 
 public class ItemEnderPouch extends Item
@@ -34,9 +35,18 @@ public class ItemEnderPouch extends Item
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean extended)
     {
-        if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
+     
+    	list.subList(1, list.size()).clear();
+    	
+    	if(stack.hasTagCompound() && !stack.getTagCompound().getString("owner").equals("global"))
             list.add(stack.getTagCompound().getString("owner"));
+    	
+    	list.add(EnderStorageManager.getUnlocalizedColorDesc(stack));	     	       
+        
     }
+  
+    	
+
     
     @Override
     public boolean onItemUseFirst(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ)
@@ -52,6 +62,9 @@ public class ItemEnderPouch extends Item
             if(!stack.hasTagCompound())
                 stack.setTagCompound(new NBTTagCompound());
             stack.getTagCompound().setString("owner", chest.owner);
+            
+            addInformation(stack, player, stack.getTooltip(player, true), true);
+            
             return true;
         }
         return false;


### PR DESCRIPTION
Given the reliance of EnderStorage on color, it can be a bit hard to use for anyone that is colorblind.

This pull adds the full localized name of the color frequencies to the tooltip of Ender Pouches, Chests, and Tanks when in the players inventory to make it easier to distinguish differently colored frequencies. So far English and German have localization support (Thanks Vexatos)

For example;
![tooltipexample](https://cloud.githubusercontent.com/assets/5694243/4410124/9ba26f3a-44e3-11e4-917c-e1d07a24be13.png)

I've tested it locally and all colors are properly reported back and there does not seem to be any other adverse effects.

If this isn't useful as is (I freely admit to being a novice java programmer) , I hope that the idea will at least inspire a change to help people use EnderStorage.
